### PR TITLE
Add control to stop/start the waydroid session

### DIFF
--- a/qml/MainPage.qml
+++ b/qml/MainPage.qml
@@ -84,13 +84,13 @@ Page {
         anchors.top: hintLabel.bottom
         anchors.topMargin: Theme.paddingLarge
         anchors.horizontalCenter: parent.horizontalCenter
-        text: runner.statusCode == Runner.ErrorSessionRunning ? qsTr("Stop Waydroid Session") : qsTr("Start Waydroid Session")
+        text: runner.statusCode == Runner.Idle ? qsTr("Start Waydroid Session") : qsTr("Stop Waydroid Session")
         visible: runner.statusCode == Runner.ErrorSessionRunning || runner.statusCode == Runner.ErrorUnexpected || runner.statusCode == Runner.Idle
 
         onClicked: {
-            if (runner.statusCode == Runner.ErrorSessionRunning) {
+            if (runner.statusCode == Runner.ErrorSessionRunning || runner.statusCode == Runner.ErrorUnexpected) {
                 runner.stopSession();
-            } else if (runner.statusCode == Runner.Idle || runner.statusCode == Runner.ErrorUnexpected) {
+            } else if (runner.statusCode == Runner.Idle) {
                 runner.start();
                 busyInd.running = true;
             } else {

--- a/qml/MainPage.qml
+++ b/qml/MainPage.qml
@@ -85,12 +85,12 @@ Page {
         anchors.topMargin: Theme.paddingLarge
         anchors.horizontalCenter: parent.horizontalCenter
         text: runner.statusCode == Runner.ErrorSessionRunning ? qsTr("Stop Waydroid Session") : qsTr("Start Waydroid Session")
-        visible: runner.statusCode == Runner.ErrorSessionRunning || runner.statusCode == Runner.Idle
+        visible: runner.statusCode == Runner.ErrorSessionRunning || runner.statusCode == Runner.ErrorUnexpected || runner.statusCode == Runner.Idle
 
         onClicked: {
             if (runner.statusCode == Runner.ErrorSessionRunning) {
                 runner.stopSession();
-            } else if (runner.statusCode == Runner.Idle) {
+            } else if (runner.statusCode == Runner.Idle || runner.statusCode == Runner.ErrorUnexpected) {
                 runner.start();
                 busyInd.running = true;
             } else {

--- a/qml/MainPage.qml
+++ b/qml/MainPage.qml
@@ -40,6 +40,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import "."
+import org.sailfishosopen 1.0
 
 Page {
     id: root
@@ -83,13 +84,13 @@ Page {
         anchors.top: hintLabel.bottom
         anchors.topMargin: Theme.paddingLarge
         anchors.horizontalCenter: parent.horizontalCenter
-        text: runner.statusCode == -2 ? qsTr("Stop Waydroid Session") : qsTr("Start Waydroid Session")
-        visible: runner.statusCode == -2 || runner.statusCode == 0
+        text: runner.statusCode == Runner.ErrorSessionRunning ? qsTr("Stop Waydroid Session") : qsTr("Start Waydroid Session")
+        visible: runner.statusCode == Runner.ErrorSessionRunning || runner.statusCode == Runner.Idle
 
         onClicked: {
-            if (runner.statusCode == -2) {
+            if (runner.statusCode == Runner.ErrorSessionRunning) {
                 runner.stopSession();
-            } else if (runner.statusCode == 0) {
+            } else if (runner.statusCode == Runner.Idle) {
                 runner.start();
                 busyInd.running = true;
             } else {

--- a/qml/MainPage.qml
+++ b/qml/MainPage.qml
@@ -79,12 +79,34 @@ Page {
         wrapMode: Text.WordWrap
     }
 
+    Button {
+        anchors.top: hintLabel.bottom
+        anchors.topMargin: Theme.paddingLarge
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: runner.statusCode == -2 ? qsTr("Stop Waydroid Session") : qsTr("Start Waydroid Session")
+        visible: runner.statusCode == -2 || runner.statusCode == 0
+
+        onClicked: {
+            if (runner.statusCode == -2) {
+                runner.stopSession();
+            } else if (runner.statusCode == 0) {
+                runner.start();
+                busyInd.running = true;
+            } else {
+                console.log("Unexpected code", runner.statusCode);
+            }
+        }
+    }
+
     // Connections and signal handlers
     Connections {
         target: runner
         onExit: {
             appFinished = true;
             busyInd.running = false;
+        }
+        onStatusChanged: {
+            console.log("Status: ", runner.statusCode, runner.status);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,8 @@ int main(int argc, char *argv[])
     app->setOrganizationName("waydroid-runner");
     app->setApplicationVersion(APP_VERSION);
 
+    qmlRegisterUncreatableType<Runner>("org.sailfishosopen", 1, 0, "Runner", "Register for enum types");
+
     QQuickView *view = SailfishApp::createView();
 
     // compositor

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -99,6 +99,7 @@ void Runner::start()
   if (!m_process_session)
     {
       m_status = tr("Session process not available, cannot start");
+      m_statusCode = -1;
       emit statusChanged();
       return;
     }
@@ -107,12 +108,22 @@ void Runner::start()
   if (m_status_session_running)
     {
       m_status = tr("Android session started already. Stop that session and restart this application.");
+      m_statusCode = -2;
       emit statusChanged();
       return;
     }
 
   m_process_session->start(WAYDROID_PATH, QStringList() << "session" << "start");
   m_status = tr("Starting Android session");
+  m_statusCode = 1;
+  emit statusChanged();
+}
+
+void Runner::stopSession()
+{
+  m_process_session->start(WAYDROID_PATH, QStringList() << "session" << "stop");
+  m_status = tr("Stopping Android session");
+  m_statusCode = 3;
   emit statusChanged();
 }
 
@@ -151,6 +162,7 @@ void Runner::onCheckSession()
           std::cerr << "Android session running using Wayland display: " << m_status_wayland_socket.toStdString() << "\n"
                     << "Expected value: " << m_wayland_socket.toStdString() << std::endl;
           m_status = tr("Unexpected Wayland display setting for running Android session. Stopping the execution.");
+          m_statusCode = -3;
           emit statusChanged();
           return;
         }
@@ -158,6 +170,7 @@ void Runner::onCheckSession()
       // this called only once as timer single shots will not be requested
       m_process_fullui->start(WAYDROID_PATH, QStringList() << "show-full-ui");
       m_status = tr("Waiting for Android UI");
+      m_statusCode = 2;
       emit statusChanged();
     }
   else
@@ -187,13 +200,16 @@ void Runner::onFinished(int exitCode, QProcess::ExitStatus exitStatus)
       emit exitCodeChanged(m_exitCode);
     }
 
-  if (m_crashed)
+  if (m_crashed) {
     m_status = tr("Android session crashed");
-  else if (m_exitCode)
+    m_statusCode = -4;
+  } else if (m_exitCode) {
     m_status = tr("Android session finished with the exit code %1").arg(m_exitCode);
-  else
+    m_statusCode = -5;
+  } else {
     m_status = tr("Android session finished");
-
+    m_statusCode = 0;
+  }
   emit statusChanged();
   emit exit();
 }

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -54,7 +54,7 @@ Runner::Runner(QString wayland_socket, QObject *parent):
   m_wayland_socket(wayland_socket)
 {
   m_status = tr("Initializing");
-
+  m_status_code = Status::Idle;
   // Wayland
   QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
   env.insert("WAYLAND_DISPLAY", wayland_socket);
@@ -99,7 +99,7 @@ void Runner::start()
   if (!m_process_session)
     {
       m_status = tr("Session process not available, cannot start");
-      m_statusCode = -1;
+      m_status_code = Status::ErrorSessionNotAvailable;
       emit statusChanged();
       return;
     }
@@ -108,14 +108,14 @@ void Runner::start()
   if (m_status_session_running)
     {
       m_status = tr("Android session started already. Stop that session and restart this application.");
-      m_statusCode = -2;
+      m_status_code = Status::ErrorSessionRunning;
       emit statusChanged();
       return;
     }
 
   m_process_session->start(WAYDROID_PATH, QStringList() << "session" << "start");
   m_status = tr("Starting Android session");
-  m_statusCode = 1;
+  m_status_code = Status::StartingSession;
   emit statusChanged();
 }
 
@@ -123,7 +123,7 @@ void Runner::stopSession()
 {
   m_process_session->start(WAYDROID_PATH, QStringList() << "session" << "stop");
   m_status = tr("Stopping Android session");
-  m_statusCode = 3;
+  m_status_code = Status::StoppingSession;
   emit statusChanged();
 }
 
@@ -162,7 +162,7 @@ void Runner::onCheckSession()
           std::cerr << "Android session running using Wayland display: " << m_status_wayland_socket.toStdString() << "\n"
                     << "Expected value: " << m_wayland_socket.toStdString() << std::endl;
           m_status = tr("Unexpected Wayland display setting for running Android session. Stopping the execution.");
-          m_statusCode = -3;
+          m_status_code = Status::ErrorUnexpected;
           emit statusChanged();
           return;
         }
@@ -170,7 +170,7 @@ void Runner::onCheckSession()
       // this called only once as timer single shots will not be requested
       m_process_fullui->start(WAYDROID_PATH, QStringList() << "show-full-ui");
       m_status = tr("Waiting for Android UI");
-      m_statusCode = 2;
+      m_status_code = Status::WaitingForUI;
       emit statusChanged();
     }
   else
@@ -202,13 +202,13 @@ void Runner::onFinished(int exitCode, QProcess::ExitStatus exitStatus)
 
   if (m_crashed) {
     m_status = tr("Android session crashed");
-    m_statusCode = -4;
+    m_status_code = Status::ErrorCrashed;
   } else if (m_exitCode) {
     m_status = tr("Android session finished with the exit code %1").arg(m_exitCode);
-    m_statusCode = -5;
+    m_status_code = Status::ErrorExited;
   } else {
     m_status = tr("Android session finished");
-    m_statusCode = 0;
+    m_status_code = Status::Idle;
   }
   emit statusChanged();
   emit exit();

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -194,17 +194,17 @@ void Runner::onFinished(int exitCode, QProcess::ExitStatus exitStatus)
       emit crashedChanged(m_crashed);
     }
 
-  if (m_exitCode != exitCode)
+  if (m_exit_code != exitCode)
     {
-      m_exitCode = exitCode;
-      emit exitCodeChanged(m_exitCode);
+      m_exit_code = exitCode;
+      emit exitCodeChanged(m_exit_code);
     }
 
   if (m_crashed) {
     m_status = tr("Android session crashed");
     m_status_code = Status::ErrorCrashed;
-  } else if (m_exitCode) {
-    m_status = tr("Android session finished with the exit code %1").arg(m_exitCode);
+  } else if (m_exit_code) {
+    m_status = tr("Android session finished with the exit code %1").arg(m_exit_code);
     m_status_code = Status::ErrorExited;
   } else {
     m_status = tr("Android session finished");

--- a/src/runner.h
+++ b/src/runner.h
@@ -50,16 +50,19 @@ class Runner : public QObject
   Q_PROPERTY(bool crashed READ crashed NOTIFY crashedChanged)
   Q_PROPERTY(int  exitCode READ exitCode NOTIFY exitCodeChanged)
   Q_PROPERTY(QString status READ status NOTIFY statusChanged)
+  Q_PROPERTY(int statusCode READ statusCode NOTIFY statusChanged)
 
 public:
   Runner(QString wayland_socket, QObject *parent=nullptr);
   virtual ~Runner();
 
   Q_INVOKABLE void start();
+  Q_INVOKABLE void stopSession();
 
   bool crashed() const { return m_crashed; }
   int  exitCode() const { return m_exitCode; }
   QString status() const { return m_status; }
+  int statusCode() const { return m_statusCode; }
 
 signals:
   void crashedChanged(bool crashed);
@@ -84,6 +87,7 @@ protected:
   QString     m_wayland_socket;
 
   QString     m_status;
+  int         m_statusCode{0};
   bool        m_status_session_running{false};
   bool        m_status_container_running{false};
   QString     m_status_wayland_socket;

--- a/src/runner.h
+++ b/src/runner.h
@@ -50,9 +50,23 @@ class Runner : public QObject
   Q_PROPERTY(bool crashed READ crashed NOTIFY crashedChanged)
   Q_PROPERTY(int  exitCode READ exitCode NOTIFY exitCodeChanged)
   Q_PROPERTY(QString status READ status NOTIFY statusChanged)
-  Q_PROPERTY(int statusCode READ statusCode NOTIFY statusChanged)
+  Q_PROPERTY(Status statusCode READ statusCode NOTIFY statusChanged)
 
 public:
+  enum class Status
+  {
+    ErrorExited = -5,
+    ErrorCrashed = -4,
+    ErrorUnexpected = -3,
+    ErrorSessionRunning = -2,
+    ErrorSessionNotAvailable = -1,
+    Idle = 0,
+    StartingSession = 1,
+    WaitingForUI= 2,
+    StoppingSession = 3,
+  };
+  Q_ENUM(Status);
+
   Runner(QString wayland_socket, QObject *parent=nullptr);
   virtual ~Runner();
 
@@ -62,7 +76,7 @@ public:
   bool crashed() const { return m_crashed; }
   int  exitCode() const { return m_exitCode; }
   QString status() const { return m_status; }
-  int statusCode() const { return m_statusCode; }
+  Status statusCode() const { return m_status_code; }
 
 signals:
   void crashedChanged(bool crashed);
@@ -87,12 +101,13 @@ protected:
   QString     m_wayland_socket;
 
   QString     m_status;
-  int         m_statusCode{0};
+  Status      m_status_code = Status::Idle;
   bool        m_status_session_running{false};
   bool        m_status_container_running{false};
   QString     m_status_wayland_socket;
   bool        m_crashed;
   int         m_exitCode;
+
 };
 
 #endif // RUNNER_H

--- a/src/runner.h
+++ b/src/runner.h
@@ -74,7 +74,7 @@ public:
   Q_INVOKABLE void stopSession();
 
   bool crashed() const { return m_crashed; }
-  int  exitCode() const { return m_exitCode; }
+  int  exitCode() const { return m_exit_code; }
   QString status() const { return m_status; }
   Status statusCode() const { return m_status_code; }
 
@@ -106,7 +106,7 @@ protected:
   bool        m_status_container_running{false};
   QString     m_status_wayland_socket;
   bool        m_crashed;
-  int         m_exitCode;
+  int         m_exit_code;
 
 };
 

--- a/translations/waydroid-runner-de_DE.ts
+++ b/translations/waydroid-runner-de_DE.ts
@@ -2,6 +2,19 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="de_DE">
 <context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../qml/MainPage.qml" line="86"/>
+        <source>Stop Waydroid Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/MainPage.qml" line="86"/>
+        <source>Start Waydroid Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Runner</name>
     <message>
         <location filename="../src/runner.cpp" line="56"/>
@@ -14,37 +27,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="109"/>
+        <location filename="../src/runner.cpp" line="110"/>
         <source>Android session started already. Stop that session and restart this application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="115"/>
+        <location filename="../src/runner.cpp" line="117"/>
         <source>Starting Android session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="153"/>
+        <location filename="../src/runner.cpp" line="125"/>
+        <source>Stopping Android session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/runner.cpp" line="164"/>
         <source>Unexpected Wayland display setting for running Android session. Stopping the execution.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="160"/>
+        <location filename="../src/runner.cpp" line="172"/>
         <source>Waiting for Android UI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="191"/>
+        <location filename="../src/runner.cpp" line="204"/>
         <source>Android session crashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="193"/>
+        <location filename="../src/runner.cpp" line="207"/>
         <source>Android session finished with the exit code %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="195"/>
+        <location filename="../src/runner.cpp" line="210"/>
         <source>Android session finished</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/waydroid-runner-de_DE.ts
+++ b/translations/waydroid-runner-de_DE.ts
@@ -4,12 +4,12 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../qml/MainPage.qml" line="86"/>
+        <location filename="../qml/MainPage.qml" line="87"/>
         <source>Stop Waydroid Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainPage.qml" line="86"/>
+        <location filename="../qml/MainPage.qml" line="87"/>
         <source>Start Waydroid Session</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/waydroid-runner.ts
+++ b/translations/waydroid-runner.ts
@@ -2,6 +2,19 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../qml/MainPage.qml" line="86"/>
+        <source>Stop Waydroid Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/MainPage.qml" line="86"/>
+        <source>Start Waydroid Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Runner</name>
     <message>
         <location filename="../src/runner.cpp" line="56"/>
@@ -14,37 +27,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="109"/>
+        <location filename="../src/runner.cpp" line="110"/>
         <source>Android session started already. Stop that session and restart this application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="115"/>
+        <location filename="../src/runner.cpp" line="117"/>
         <source>Starting Android session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="153"/>
+        <location filename="../src/runner.cpp" line="125"/>
+        <source>Stopping Android session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/runner.cpp" line="164"/>
         <source>Unexpected Wayland display setting for running Android session. Stopping the execution.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="160"/>
+        <location filename="../src/runner.cpp" line="172"/>
         <source>Waiting for Android UI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="191"/>
+        <location filename="../src/runner.cpp" line="204"/>
         <source>Android session crashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="193"/>
+        <location filename="../src/runner.cpp" line="207"/>
         <source>Android session finished with the exit code %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/runner.cpp" line="195"/>
+        <location filename="../src/runner.cpp" line="210"/>
         <source>Android session finished</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/waydroid-runner.ts
+++ b/translations/waydroid-runner.ts
@@ -4,12 +4,12 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../qml/MainPage.qml" line="86"/>
+        <location filename="../qml/MainPage.qml" line="87"/>
         <source>Stop Waydroid Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainPage.qml" line="86"/>
+        <location filename="../qml/MainPage.qml" line="87"/>
         <source>Start Waydroid Session</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Helps in the case where waydroid thinks the session is running after a
reboot or waydroid-runner was killed, leaving the session running.